### PR TITLE
Allow configuration of autoCloseTimeout from node interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-red-contrib-smb",
+  "name": "@eflexsystems/node-red-contrib-smb",
   "version": "1.2.0",
   "description": "Node of Node-RED for SMB protocol.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@eflexsystems/node-red-contrib-smb",
+  "name": "node-red-contrib-smb",
   "version": "1.2.0",
-  "description": "Node of Node-RED for SMB protocol.",
+  "description": "Node-RED for the SMB protocol",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -15,7 +15,7 @@
       "SMB": "red/smb.js"
     }
   },
-  "author": "Smart-Tech",
+  "author": "ST-One Ltda.",
   "license": "Apache-2.0",
   "dependencies": {
     "@marsaud/smb2": "^0.17.1"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "author": "Smart-Tech",
   "license": "Apache-2.0",
   "dependencies": {
-    "@marsaud/smb2": "^0.14.0"
+    "@marsaud/smb2": "^0.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-smb",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Node of Node-RED for SMB protocol.",
   "main": "index.js",
   "scripts": {

--- a/red/locales/en-US/smb.json
+++ b/red/locales/en-US/smb.json
@@ -4,6 +4,7 @@
             "name": "Name",
             "share": "Share",
             "domain": "Domain",
+            "timeout": "Timeout",
             "username": "Username",
             "password": "Password",
             "config": "Config",
@@ -15,6 +16,7 @@
         "placeholder": {
             "share": "\\\\address\\share",
             "domain": "domain.local",
+            "timeout": "0",
             "username": "username",
             "password": "password",
             "path": "some\\path",

--- a/red/smb.html
+++ b/red/smb.html
@@ -261,6 +261,14 @@ limitations under the License.
     </div>
 
     <div class="form-row">
+        <label for="node-config-input-timeout">
+            <i class="fa fa-clock-o"></i>
+            <span data-i18n="smb.label.timeout"></span>
+        </label>
+        <input type="number" id="node-config-input-timeout" data-i18n="[placeholder]smb.placeholder.timeout">
+    </div>
+
+    <div class="form-row">
         <label for="node-config-input-username">
             <i class="fa fa-user"></i>
             <span data-i18n="smb.label.username"></span>
@@ -310,6 +318,14 @@ limitations under the License.
             empty if the target is not part of a domain
         </dd>
 
+        <dt>Timeout
+            <span class="property-type">number</span>
+        </dt>
+        <dd>
+            The timeout in milliseconds before closing the
+            SMB session and the socket. default: <code>0</code>
+        </dd>
+
         <dt>Username
             <span class="property-type">string</span>
         </dt>
@@ -335,6 +351,9 @@ limitations under the License.
             },
             domain: {
                 value: ""
+            },
+            timeout: {
+              value: 0
             }
         },
         credentials: {

--- a/red/smb.js
+++ b/red/smb.js
@@ -27,7 +27,7 @@ module.exports = function (RED) {
         self.domain = values.domain || ".";
         self.username = self.credentials.username || "";
         self.password = self.credentials.password || "";
-        self.autoCloseTimeout = 0;
+        self.autoCloseTimeout = values.timeout || 0;
 
         self.on("close", (done) => {
             self.smbClient.disconnect();
@@ -45,7 +45,7 @@ module.exports = function (RED) {
                 domain: self.domain,
                 username: self.username,
                 password: self.password,
-                autoCloseTimeout: 0
+                autoCloseTimeout: self.autoCloseTimeout
             });
         }
 


### PR DESCRIPTION
We have a case where we do want the SMB connection to timeout. This adds the ability to configure the timeout in the smb config node. It defaults to `0` so it should be fully backwards compatible.